### PR TITLE
Add a branch alias for dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,4 +16,9 @@
     "autoload": {
         "files": ["getid3/getid3.php", "getid3/write.php"]
     }
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
+    }
 }


### PR DESCRIPTION
Map the dev-master branch to release 1.0.x-dev, so users can require
version ~1.0 in their composer.json files.
