### PR TITLE
getid3_writetags::__construct()

### DIFF
--- a/getid3/write.php
+++ b/getid3/write.php
@@ -63,7 +63,7 @@ class getid3_writetags
 	// private
 	var $ThisFileInfo; // analysis of file before writing
 
-	function getid3_writetags() {
+	function __construct() {
 		return true;
 	}
 


### PR DESCRIPTION
Fixes: 
```
PHP Deprecated:  Methods with the same name as their class will not be constructors in a future version of PHP; getid3_writetags has a deprecated constructor in vendor/nass600/get-id3/getid3/write.php on line 47
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nass600/getid3/6)
<!-- Reviewable:end -->
